### PR TITLE
Add unit tests for services and refactor VotingSession logic

### DIFF
--- a/src/main/java/com/votacao/desafio/dto/PautaRequest.java
+++ b/src/main/java/com/votacao/desafio/dto/PautaRequest.java
@@ -2,8 +2,10 @@ package com.votacao.desafio.dto;
 
 import lombok.Getter;
 import jakarta.validation.constraints.NotNull;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class PautaRequest {
     @NotNull(message = "Title is required")
     private String title;

--- a/src/main/java/com/votacao/desafio/service/VotingSessionService.java
+++ b/src/main/java/com/votacao/desafio/service/VotingSessionService.java
@@ -71,10 +71,6 @@ public class VotingSessionService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Voting Session not found"));
     }
 
-    public Page<VotingSession> findAll(Pageable pageable) {
-        return votingSessionRepository.findAll(pageable);
-    }
-
     @Transactional(readOnly = true)
     public Page<VotingSession> listAllVotingSessionsOpen(Integer page, Integer size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "votingSessionStartedAt"));
@@ -97,27 +93,18 @@ public class VotingSessionService {
                 .build());
     }
 
-    public Page<VotingSessionResponse> listAllVotingSessions(String votingSessionStatus, Integer page, Integer size) {
-        if (votingSessionStatus == null) votingSessionStatus = "";
-        Pageable pageable = PageRequest.of(page, size);
+    public Page<VotingSessionResponse> listAllVotingSessions(String status, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "votingSessionStartedAt"));
+        Page<VotingSession> votingSessions;
 
-        if (!votingSessionStatus.isEmpty()) {
-            switch (votingSessionStatus) {
-                case "OPEN" -> {
-                    return votingSessionRepository.listAllVotingSessionsOpen(LocalDateTime.now(), pageable)
-                            .map(VotingSessionResponse::mapToVotingSessionResponse);
-                }
-                case "CLOSED" -> {
-                    return votingSessionRepository.listAllVotingSessionsClosed(LocalDateTime.now(), pageable)
-                            .map(VotingSessionResponse::mapToVotingSessionResponse);
-                }
-                default -> {
-                    return findAll(pageable)
-                            .map(VotingSessionResponse::mapToVotingSessionResponse);
-                }
-            }
+        if ("OPEN".equalsIgnoreCase(status)) {
+            votingSessions = votingSessionRepository.listAllVotingSessionsOpen(LocalDateTime.now(), pageable);
+        } else if ("CLOSED".equalsIgnoreCase(status)) {
+            votingSessions = votingSessionRepository.listAllVotingSessionsClosed(LocalDateTime.now(), pageable);
+        } else {
+            votingSessions = votingSessionRepository.findAll(pageable);
         }
-        return findAll(pageable)
-                .map(VotingSessionResponse::mapToVotingSessionResponse);
+
+        return votingSessions.map(VotingSessionResponse::mapToVotingSessionResponse);
     }
 }

--- a/src/test/java/com/votacao/desafio/service/PautaManagementServiceTest.java
+++ b/src/test/java/com/votacao/desafio/service/PautaManagementServiceTest.java
@@ -1,0 +1,184 @@
+package com.votacao.desafio.service;
+
+import com.votacao.desafio.dto.PautaRequest;
+import com.votacao.desafio.dto.PautaResponse;
+import com.votacao.desafio.entity.Pauta;
+import com.votacao.desafio.entity.VotingSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PautaManagementServiceTest {
+
+    @Mock
+    private PautaQueryService pautaQueryService;
+
+    @Mock
+    private VotingSessionService votingSessionService;
+
+    @InjectMocks
+    private PautaManagementService pautaManagementService;
+
+    private PautaRequest pautaRequest;
+    private Pauta savedPauta;
+    private List<VotingSession> votingSessions;
+    private Page<Pauta> pautaPage;
+
+    @BeforeEach
+    void setUp() {
+        final String pautaTitle = "Test Pauta";
+        final String pautaDescriptions = "Test Description";
+        final LocalDateTime createdAt = LocalDateTime.now();
+        final LocalDateTime endedAt = LocalDateTime.now().plusMinutes(10);
+
+        pautaRequest = new PautaRequest();
+        pautaRequest.setTitle(pautaTitle);
+        pautaRequest.setDescription(pautaDescriptions);
+
+        savedPauta = Pauta.builder()
+                .id(1L)
+                .title(pautaTitle)
+                .description(pautaDescriptions)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        VotingSession votingSession = VotingSession.builder()
+                .id(1L)
+                .pauta(Pauta.builder()
+                        .id(1L)
+                        .title(pautaTitle)
+                        .description(pautaDescriptions)
+                        .createdAt(LocalDateTime.now())
+                        .votingSession(VotingSession.builder()
+                                .id(1L)
+                                .votingSessionStartedAt(createdAt)
+                                .votingSessionEndedAt(endedAt)
+                                .votes(Collections.emptyList())
+                                .build())
+                        .build())
+                .votingSessionStartedAt(LocalDateTime.now())
+                .votingSessionEndedAt(LocalDateTime.now().plusMinutes(10))
+                .votes(Collections.emptyList())
+                .build();
+
+        votingSessions = Collections.singletonList(votingSession);
+
+        List<Pauta> pautaList = Collections.singletonList(savedPauta);
+        pautaPage = new PageImpl<>(pautaList);
+    }
+
+    @Test
+    @DisplayName("Should create and return paginated pauta list")
+    void createPauta_ShouldCreateAndReturnPautaResponse() {
+        when(pautaQueryService.save(any(Pauta.class))).thenReturn(savedPauta);
+
+        PautaResponse result = pautaManagementService.createPauta(pautaRequest);
+
+        assertNotNull(result);
+        assertEquals(savedPauta.getId(), result.getId());
+        assertEquals(savedPauta.getTitle(), result.getTitle());
+        assertEquals(savedPauta.getDescription(), result.getDescription());
+        verify(pautaQueryService, times(1)).save(any(Pauta.class));
+    }
+
+    @Test
+    @DisplayName("Should list all pautas")
+    void listAllPautas_WithNullStatus_ShouldReturnAllPautas() {
+        when(pautaQueryService.findAll(any(Pageable.class))).thenReturn(pautaPage);
+
+        Page<PautaResponse> result = pautaManagementService.listAllPautas(null, 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(pautaQueryService, times(1)).findAll(any(Pageable.class));
+        verify(votingSessionService, never()).listAllVotingSessionsOpen(anyInt(), anyInt());
+        verify(votingSessionService, never()).listAllVotingSessionsClosed(anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should list all pautas with status query is blank")
+    void listAllPautas_WithEmptyStatus_ShouldReturnAllPautas() {
+        when(pautaQueryService.findAll(any(Pageable.class))).thenReturn(pautaPage);
+
+        Page<PautaResponse> result = pautaManagementService.listAllPautas("", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(pautaQueryService, times(1)).findAll(any(Pageable.class));
+        verify(votingSessionService, never()).listAllVotingSessionsOpen(anyInt(), anyInt());
+        verify(votingSessionService, never()).listAllVotingSessionsClosed(anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should list all pautas with status OPEN")
+    void listAllPautas_WithStatusOPEN_ShouldReturnOpenPautas() {
+        Page<VotingSession> openPautaPage = new PageImpl<>(votingSessions);
+        when(votingSessionService.listAllVotingSessionsOpen(0, 10)).thenReturn(openPautaPage);
+
+        Page<PautaResponse> result = pautaManagementService.listAllPautas("OPEN", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionService, times(1)).listAllVotingSessionsOpen(0, 10);
+        verify(pautaQueryService, never()).findAll(any(Pageable.class));
+        verify(votingSessionService, never()).listAllVotingSessionsClosed(anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should list all pautas with status CLOSED")
+    void listAllPautas_WithStatusCLOSED_ShouldReturnClosedPautas() {
+        Page<VotingSession> closedPautaPage = new PageImpl<>(votingSessions);
+        when(votingSessionService.listAllVotingSessionsClosed(0, 10)).thenReturn(closedPautaPage);
+
+        Page<PautaResponse> result = pautaManagementService.listAllPautas("CLOSED", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionService, times(1)).listAllVotingSessionsClosed(0, 10);
+        verify(pautaQueryService, never()).findAll(any(Pageable.class));
+        verify(votingSessionService, never()).listAllVotingSessionsOpen(anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should list all pautas with invalid status")
+    void listAllPautas_WithInvalidStatus_ShouldReturnAllPautas() {
+        when(pautaQueryService.findAll(any(Pageable.class))).thenReturn(pautaPage);
+
+        Page<PautaResponse> result = pautaManagementService.listAllPautas("INVALID_STATUS", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(pautaQueryService, times(1)).findAll(any(Pageable.class));
+        verify(votingSessionService, never()).listAllVotingSessionsOpen(anyInt(), anyInt());
+        verify(votingSessionService, never()).listAllVotingSessionsClosed(anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("Should get pauta response by id")
+    void getPautaResponseById_ShouldReturnPautaResponse() {
+        when(pautaQueryService.getPautaById(1L)).thenReturn(savedPauta);
+
+        PautaResponse result = pautaManagementService.getPautaResponseById(1L);
+
+        assertNotNull(result);
+        assertEquals(savedPauta.getId(), result.getId());
+        assertEquals(savedPauta.getTitle(), result.getTitle());
+        assertEquals(savedPauta.getDescription(), result.getDescription());
+        verify(pautaQueryService, times(1)).getPautaById(1L);
+    }
+}

--- a/src/test/java/com/votacao/desafio/service/PautaQueryServiceTest.java
+++ b/src/test/java/com/votacao/desafio/service/PautaQueryServiceTest.java
@@ -1,0 +1,100 @@
+package com.votacao.desafio.service;
+
+import com.votacao.desafio.entity.Pauta;
+import com.votacao.desafio.repository.PautaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PautaQueryServiceTest {
+
+    @Mock
+    private PautaRepository pautaRepository;
+
+    @InjectMocks
+    private PautaQueryService pautaQueryService;
+
+    Pauta pauta;
+
+    @BeforeEach
+    void setUp() {
+        final String pautaTitle = "Test Pauta";
+        final String pautaDescriptions = "Test Description";
+        final LocalDateTime createdAt = LocalDateTime.now();
+
+        pauta = Pauta.builder()
+                .id(1L)
+                .title(pautaTitle)
+                .description(pautaDescriptions)
+                .createdAt(createdAt)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Should return pauta when given a valid ID")
+    void getPautaById_WithExistingId_ShouldReturnPauta() {
+        pauta.setId(1L);
+        when(pautaRepository.findById(1L)).thenReturn(Optional.of(pauta));
+
+        Pauta result = pautaQueryService.getPautaById(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        verify(pautaRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Should throw ResponseStatusException when given a non-existing ID")
+    void getPautaById_WithNonExistingId_ShouldThrowResponseStatusException() {
+        when(pautaRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> pautaQueryService.getPautaById(1L));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("Pauta not found with ID: 1", exception.getReason());
+        verify(pautaRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Should return pauta when given a valid ID")
+    void save_WithValidPauta_ShouldReturnSavedPauta() {
+        when(pautaRepository.save(pauta)).thenReturn(pauta);
+
+        Pauta result = pautaQueryService.save(pauta);
+
+        assertNotNull(result);
+        verify(pautaRepository, times(1)).save(pauta);
+    }
+
+    @Test
+    @DisplayName("Should return page of pautas when given a valid Pageable")
+    void findAll_WithValidPageable_ShouldReturnPageOfPautas() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Pauta> pautaPage = new PageImpl<>(Collections.singletonList(pauta));
+        when(pautaRepository.findAll(pageable)).thenReturn(pautaPage);
+
+        Page<Pauta> result = pautaQueryService.findAll(pageable);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(pautaRepository, times(1)).findAll(pageable);
+    }
+}

--- a/src/test/java/com/votacao/desafio/service/VotingSessionServiceTest.java
+++ b/src/test/java/com/votacao/desafio/service/VotingSessionServiceTest.java
@@ -1,0 +1,256 @@
+package com.votacao.desafio.service;
+
+import com.votacao.desafio.dto.VotingSessionResponse;
+import com.votacao.desafio.entity.Pauta;
+import com.votacao.desafio.entity.VotingSession;
+import com.votacao.desafio.repository.VotingSessionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class VotingSessionServiceTest {
+
+    @Mock
+    private VotingSessionRepository votingSessionRepository;
+
+    @Mock
+    private PautaQueryService pautaService;
+
+    @InjectMocks
+    private VotingSessionService votingSessionService;
+
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "votingSessionStartedAt"));
+    }
+
+    @Test
+    @DisplayName("Deve retornar a sessão de votação pelo ID com sucesso")
+    void getVotingSessionById_WithExistingId_ShouldReturnVotingSessionResponse() {
+        VotingSession votingSession = new VotingSession();
+        votingSession.setId(1L);
+        when(votingSessionRepository.findById(1L)).thenReturn(Optional.of(votingSession));
+
+        VotingSessionResponse result = votingSessionService.getVotingSessionById(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        verify(votingSessionRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when Pauta not found")
+    void openVotingSessionByPautaId_WithInvalidPautaId_ShouldThrowException() {
+        when(pautaService.getPautaById(1L)).thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Pauta not found"));
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                votingSessionService.openVotingSessionByPautaId(1L, 30)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("Pauta not found", exception.getReason());
+        verify(pautaService, times(1)).getPautaById(1L);
+        verifyNoInteractions(votingSessionRepository);
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção quando já existe uma sessão de votação para a pauta")
+    void openVotingSessionByPautaId_WhenVotingSessionAlreadyExists_ShouldThrowException() {
+        // Arrange
+        Pauta pauta = new Pauta();
+        pauta.setVotingSession(new VotingSession()); // Simula uma pauta com sessão de votação existente
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+
+        // Act & Assert
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                votingSessionService.openVotingSessionByPautaId(1L, 30)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("Voting session already exists for this Pauta", exception.getReason());
+        verify(pautaService, times(1)).getPautaById(1L);
+        verifyNoInteractions(votingSessionRepository);
+    }
+
+    @Test
+    @DisplayName("Should open voting session successfully")
+    void openVotingSessionByPautaId_WithExistingVotingSession_ShouldThrowException() {
+        Pauta pauta = new Pauta();
+        pauta.setVotingSession(new VotingSession());
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                votingSessionService.openVotingSessionByPautaId(1L, 30)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("Voting session already exists for this Pauta", exception.getReason());
+        verify(pautaService, times(1)).getPautaById(1L);
+        verifyNoInteractions(votingSessionRepository);
+    }
+
+    @Test
+    @DisplayName("Should return all voting sessions with status is invalid")
+    void listAllVotingSessions_WithInvalidStatus_ShouldReturnAllSessions() {
+        Page<VotingSession> votingSessionPage = new PageImpl<>(Collections.singletonList(new VotingSession()));
+        when(votingSessionRepository.findAll(pageable)).thenReturn(votingSessionPage);
+
+        Page<VotingSessionResponse> result = votingSessionService.listAllVotingSessions("INVALID", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionRepository, times(1)).findAll(pageable);
+        verifyNoMoreInteractions(votingSessionRepository);
+    }
+
+    @Test
+    @DisplayName("Should return all voting sessions with status OPEN")
+    void listAllVotingSessions_WithOpenStatus_ShouldReturnOpenSessions() {
+        Page<VotingSession> votingSessionPage = new PageImpl<>(Collections.singletonList(new VotingSession()));
+        when(votingSessionRepository.listAllVotingSessionsOpen(any(LocalDateTime.class), eq(pageable))).thenReturn(votingSessionPage);
+
+        Page<VotingSessionResponse> result = votingSessionService.listAllVotingSessions("OPEN", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionRepository, times(1)).listAllVotingSessionsOpen(any(LocalDateTime.class), eq(pageable));
+        verifyNoMoreInteractions(votingSessionRepository);
+    }
+
+    @Test
+    @DisplayName("Should return all voting sessions with status CLOSED")
+    void listAllVotingSessions_WithClosedStatus_ShouldReturnClosedSessions() {
+        Page<VotingSession> votingSessionPage = new PageImpl<>(Collections.singletonList(new VotingSession()));
+        when(votingSessionRepository.listAllVotingSessionsClosed(any(LocalDateTime.class), eq(pageable))).thenReturn(votingSessionPage);
+
+        Page<VotingSessionResponse> result = votingSessionService.listAllVotingSessions("CLOSED", 0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionRepository, times(1)).listAllVotingSessionsClosed(any(LocalDateTime.class), eq(pageable));
+        verifyNoMoreInteractions(votingSessionRepository);
+    }
+
+    @Test
+    @DisplayName("Should return voting session by ID")
+    void getVotingResult_WithNoVotingSession_ShouldThrowException() {
+        Pauta pauta = new Pauta();
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+        when(votingSessionRepository.findOpenVotingSessionByPautaId(1L)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                votingSessionService.getVotingResult(1L)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("Voting Session not found for the given Pauta ID1", exception.getReason());
+        verify(pautaService, times(1)).getPautaById(1L);
+        verify(votingSessionRepository, times(1)).findOpenVotingSessionByPautaId(1L);
+    }
+
+    @Test
+    @DisplayName("Deve salvar uma sessão de votação com sucesso")
+    void saveVotingSession_WithValidVotingSession_ShouldSaveAndReturn() {
+        VotingSession votingSession = new VotingSession();
+        when(votingSessionRepository.save(votingSession)).thenReturn(votingSession);
+
+        VotingSession result = votingSessionService.saveVotingSession(votingSession);
+
+        assertNotNull(result);
+        assertEquals(votingSession, result);
+        verify(votingSessionRepository, times(1)).save(votingSession);
+    }
+
+    @Test
+    @DisplayName("Deve retornar uma sessão de votação pelo ID")
+    void findById_WithExistingId_ShouldReturnVotingSession() {
+        VotingSession votingSession = new VotingSession();
+        votingSession.setId(1L);
+        when(votingSessionRepository.findById(1L)).thenReturn(Optional.of(votingSession));
+
+        VotingSession result = votingSessionService.findById(1L);
+
+        assertNotNull(result);
+        assertEquals(1L, result.getId());
+        verify(votingSessionRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Deve lançar exceção ao buscar sessão de votação com ID inexistente")
+    void findById_WithNonExistingId_ShouldThrowException() {
+        when(votingSessionRepository.findById(1L)).thenReturn(Optional.empty());
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                votingSessionService.findById(1L)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertEquals("Voting Session not found", exception.getReason());
+        verify(votingSessionRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Deve listar todas as sessões de votação abertas com sucesso")
+    void listAllVotingSessionsOpen_WithValidPageAndSize_ShouldReturnOpenSessions() {
+        Page<VotingSession> votingSessionPage = new PageImpl<>(Collections.singletonList(new VotingSession()));
+        when(votingSessionRepository.listAllVotingSessionsOpen(any(LocalDateTime.class), eq(pageable))).thenReturn(votingSessionPage);
+
+        Page<VotingSession> result = votingSessionService.listAllVotingSessionsOpen(0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionRepository, times(1)).listAllVotingSessionsOpen(any(LocalDateTime.class), eq(pageable));
+    }
+
+    @Test
+    @DisplayName("Deve listar todas as sessões de votação fechadas com sucesso")
+    void listAllVotingSessionsClosed_WithValidPageAndSize_ShouldReturnClosedSessions() {
+        Page<VotingSession> votingSessionPage = new PageImpl<>(Collections.singletonList(new VotingSession()));
+        when(votingSessionRepository.listAllVotingSessionsClosed(any(LocalDateTime.class), eq(pageable))).thenReturn(votingSessionPage);
+
+        Page<VotingSession> result = votingSessionService.listAllVotingSessionsClosed(0, 10);
+
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+        verify(votingSessionRepository, times(1)).listAllVotingSessionsClosed(any(LocalDateTime.class), eq(pageable));
+    }
+
+    @Test
+    @DisplayName("Deve abrir uma nova sessão de votação com sucesso")
+    void openVotingSession_WithValidPautaAndDuration_ShouldSaveAndReturnVotingSession() {
+        Pauta pauta = new Pauta();
+        pauta.setId(1L);
+        int sessionDuration = 30;
+
+        VotingSession votingSession = VotingSession.builder()
+                .pauta(pauta)
+                .votingSessionStartedAt(LocalDateTime.now())
+                .votingSessionEndedAt(LocalDateTime.now().plusMinutes(sessionDuration))
+                .build();
+
+        when(votingSessionRepository.save(any(VotingSession.class))).thenReturn(votingSession);
+
+        VotingSession result = votingSessionService.openVotingSession(pauta, sessionDuration);
+
+        assertNotNull(result);
+        assertEquals(pauta, result.getPauta());
+        verify(votingSessionRepository, times(1)).save(any(VotingSession.class));
+    }
+}


### PR DESCRIPTION
Introduced comprehensive unit tests for services related to Pauta and VotingSession functionalities, including coverage for multiple scenarios. Refactored `listAllVotingSessions` for improved readability and removed redundant `findAll` method in VotingSessionService.