### PR TITLE
Add vote registration tests and refactor voting result handling

### DIFF
--- a/src/main/java/com/votacao/desafio/controller/PautaController.java
+++ b/src/main/java/com/votacao/desafio/controller/PautaController.java
@@ -2,6 +2,7 @@ package com.votacao.desafio.controller;
 
 import com.votacao.desafio.dto.PautaRequest;
 import com.votacao.desafio.dto.PautaResponse;
+import com.votacao.desafio.dto.VotingResultResponse;
 import com.votacao.desafio.service.PautaManagementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -35,5 +36,11 @@ public class PautaController {
     public ResponseEntity<PautaResponse> getPautaById(@PathVariable Long pautaId) {
         PautaResponse pauta = pautaManagementService.getPautaResponseById(pautaId);
         return ResponseEntity.ok(pauta);
+    }
+
+    @GetMapping("/{pautaId}/resultado")
+    public ResponseEntity<VotingResultResponse> getVotingResult(@PathVariable Long pautaId) {
+        VotingResultResponse votingResult = pautaManagementService.getVotingResult(pautaId);
+        return ResponseEntity.ok(votingResult);
     }
 }

--- a/src/main/java/com/votacao/desafio/controller/VotingSessionController.java
+++ b/src/main/java/com/votacao/desafio/controller/VotingSessionController.java
@@ -36,10 +36,4 @@ public class VotingSessionController {
         VotingSessionResponse sessao = votingSessionService.getVotingSessionById(sessaoId);
         return ResponseEntity.ok(sessao);
     }
-
-    @GetMapping("/pauta/{pautaId}/resultado")
-    public ResponseEntity<VotingResultResponse> consultarResultado(@PathVariable Long pautaId) {
-        VotingResultResponse resultado = votingSessionService.getVotingResult(pautaId);
-        return ResponseEntity.ok(resultado);
-    }
 }

--- a/src/main/java/com/votacao/desafio/dto/AssociateRequest.java
+++ b/src/main/java/com/votacao/desafio/dto/AssociateRequest.java
@@ -11,4 +11,12 @@ public class AssociateRequest {
     private String cpf;
     @NotNull(message = "Email is required")
     private String email;
+
+    public String getCpf() {
+        return cpf.replaceAll("[^0-9]", "");
+    }
+
+    public String getEmail() {
+        return email.toLowerCase();
+    }
 }

--- a/src/main/java/com/votacao/desafio/dto/VoteRequest.java
+++ b/src/main/java/com/votacao/desafio/dto/VoteRequest.java
@@ -3,7 +3,9 @@ package com.votacao.desafio.dto;
 import com.votacao.desafio.entity.Vote;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class VoteRequest {
     @NotNull(message = "Associate CPF is required")

--- a/src/main/java/com/votacao/desafio/dto/VotingResultResponse.java
+++ b/src/main/java/com/votacao/desafio/dto/VotingResultResponse.java
@@ -21,6 +21,27 @@ public class VotingResultResponse {
     private String description;
     private LocalDateTime createdAt;
     private VotingSessionResponse votingSession;
+    private PautaResultResponse votingResult;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class PautaResultResponse {
+        private Integer votesCount;
+        private Integer votesCountYes;
+        private Integer votesCountNo;
+        private Double percentageYes;
+        private Double percentageNo;
+        private VotingResult result;
+
+        public enum VotingResult {
+            APPROVED,
+            REPROVED,
+            TIE,
+            IN_PROGRESS
+        }
+    }
 
     public static VotingResultResponse buildVotingResultResponse(Pauta pauta, VotingSession votingSession) {
         VotingResultResponse resultado = new VotingResultResponse();
@@ -37,29 +58,42 @@ public class VotingResultResponse {
                 .build();
 
         List<Vote> votes = votingSession.getVotes();
-        List<VoteResponse> voteResponses = votes.stream().map(voto -> {
-                    VoteResponse voteResponse = new VoteResponse();
-                    voteResponse.setId(voto.getId());
-                    voteResponse.setAssociateId(voto.getAssociate().getId());
-                    voteResponse.setAssociateName(voto.getAssociate().getName());
-                    voteResponse.setAssociateCpf(voto.getAssociate().getCpf());
-                    voteResponse.setVotedOption(voto.getVoteOption().name());
-                    voteResponse.setVotedAt(voto.getVotedAt());
-                    return voteResponse;
-                })
+        List<VoteResponse> voteResponses = votes.stream()
+                .map(VoteResponse::mapToVoteResponse)
                 .toList();
         sessionResponse.setVotes(voteResponses);
 
-        sessionResponse.setVotesCount(votes.size());
-        sessionResponse.setVotesCountYes((int) votes.stream()
-                .filter(vote -> "YES".equals(vote.getVoteOption().name()))
-                .count());
-        sessionResponse.setVotesCountNo((int) votes.stream()
+        int votesCountNo = (int) votes.stream()
                 .filter(vote -> "NO".equals(vote.getVoteOption().name()))
-                .count());
-
+                .count();
+        int votesCountYes = (int) votes.stream()
+                .filter(vote -> "YES".equals(vote.getVoteOption().name()))
+                .count();
+        PautaResultResponse pautaResult = PautaResultResponse.builder()
+                .votesCount(votes.size())
+                .votesCountYes(votesCountYes)
+                .votesCountNo(votesCountNo)
+                .percentageYes((double) votesCountYes / votes.size() * 100)
+                .percentageNo((double) votesCountNo / votes.size() * 100)
+                .result(calculateVotingResult(votesCountYes, votesCountNo, sessionResponse.getVotingSessionStatus()))
+                .build();
+        resultado.setVotingResult(pautaResult);
         resultado.setVotingSession(sessionResponse);
 
         return resultado;
+    }
+
+    private static PautaResultResponse.VotingResult calculateVotingResult(Integer votesCountYes, Integer votesCountNo, String votingSessionStatus) {
+        if (votingSessionStatus.equals("CLOSED")) {
+            if (votesCountYes > votesCountNo) {
+                return PautaResultResponse.VotingResult.APPROVED;
+            } else if (votesCountYes < votesCountNo) {
+                return PautaResultResponse.VotingResult.REPROVED;
+            } else {
+                return PautaResultResponse.VotingResult.TIE;
+            }
+        } else {
+            return PautaResultResponse.VotingResult.IN_PROGRESS;
+        }
     }
 }

--- a/src/main/java/com/votacao/desafio/dto/VotingSessionResponse.java
+++ b/src/main/java/com/votacao/desafio/dto/VotingSessionResponse.java
@@ -1,6 +1,5 @@
 package com.votacao.desafio.dto;
 
-import com.votacao.desafio.entity.Vote;
 import com.votacao.desafio.entity.VotingSession;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,12 +20,6 @@ public class VotingSessionResponse {
     private String votingSessionStatus;
     @Builder.Default
     private List<VoteResponse> votes = List.of();
-    @Builder.Default
-    private Integer votesCount = 0;
-    @Builder.Default
-    private Integer votesCountYes = 0;
-    @Builder.Default
-    private Integer votesCountNo = 0;
 
     public static VotingSessionResponse mapToVotingSessionResponse(VotingSession votingSession) {
         VotingSessionResponse response = new VotingSessionResponse();
@@ -39,18 +32,6 @@ public class VotingSessionResponse {
             response.setVotes(votingSession.getVotes().stream()
                     .map(VoteResponse::mapToVoteResponse)
                     .toList());
-            List<Vote> votes = votingSession.getVotes();
-            response.setVotesCount(votes.size());
-
-            long yesVoteCount = votes.stream()
-                    .filter(vote -> "YES".equals(vote.getVoteOption().name()))
-                    .count();
-            response.setVotesCountYes((int) yesVoteCount);
-
-            long noVoteCount = votes.stream()
-                    .filter(vote -> "NO".equals(vote.getVoteOption().name()))
-                    .count();
-            response.setVotesCountNo((int) noVoteCount);
         }
 
         return response;

--- a/src/main/java/com/votacao/desafio/service/CpfValidationService.java
+++ b/src/main/java/com/votacao/desafio/service/CpfValidationService.java
@@ -1,12 +1,10 @@
 package com.votacao.desafio.service;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class CpfValidationService {
 
     public enum StatusVotacao {

--- a/src/main/java/com/votacao/desafio/service/PautaManagementService.java
+++ b/src/main/java/com/votacao/desafio/service/PautaManagementService.java
@@ -2,7 +2,9 @@ package com.votacao.desafio.service;
 
 import com.votacao.desafio.dto.PautaRequest;
 import com.votacao.desafio.dto.PautaResponse;
+import com.votacao.desafio.dto.VotingResultResponse;
 import com.votacao.desafio.entity.Pauta;
+import com.votacao.desafio.entity.VotingSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
+
+import static com.votacao.desafio.dto.VotingResultResponse.buildVotingResultResponse;
 
 @Slf4j
 @Service
@@ -64,5 +68,18 @@ public class PautaManagementService {
     public PautaResponse getPautaResponseById(Long pautaId) {
         Pauta pauta = pautaQueryService.getPautaById(pautaId);
         return PautaResponse.mapToPautaResponse(pauta);
+    }
+
+    public VotingResultResponse getVotingResult(Long pautaId) {
+        Pauta pauta = pautaQueryService.getPautaById(pautaId);
+
+        VotingSession votingSession = votingSessionService.getOpenVotingSessionById(pautaId);
+
+        if (pauta.getVotingSession() == null) {
+            log.error("Pauta with ID {} does not have an voting session opened", pautaId);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Pauta with ID " + pautaId + " does not have an voting session opened");
+        }
+
+        return buildVotingResultResponse(pauta, votingSession);
     }
 }

--- a/src/main/java/com/votacao/desafio/service/VotingSessionService.java
+++ b/src/main/java/com/votacao/desafio/service/VotingSessionService.java
@@ -47,18 +47,10 @@ public class VotingSessionService {
         return mapToVotingSessionResponse(votingSession);
     }
 
-    public VotingResultResponse getVotingResult(Long pautaId) {
-        Pauta pauta = pautaService.getPautaById(pautaId);
-
-        VotingSession votingSession = votingSessionRepository.findOpenVotingSessionByPautaId(pautaId)
+    @Transactional(readOnly = true)
+    public VotingSession getOpenVotingSessionById(Long pautaId) {
+        return votingSessionRepository.findOpenVotingSessionByPautaId(pautaId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Voting Session not found for the given Pauta ID" + pautaId));
-
-        if (pauta.getVotingSession() == null) {
-            log.error("Pauta with ID {} does not have an voting session opened", pautaId);
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Pauta with ID " + pautaId + " does not have an voting session opened");
-        }
-
-        return buildVotingResultResponse(pauta, votingSession);
     }
 
     @Transactional

--- a/src/test/java/com/votacao/desafio/service/PautaManagementServiceTest.java
+++ b/src/test/java/com/votacao/desafio/service/PautaManagementServiceTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -181,4 +183,18 @@ class PautaManagementServiceTest {
         assertEquals(savedPauta.getDescription(), result.getDescription());
         verify(pautaQueryService, times(1)).getPautaById(1L);
     }
+
+//    @Test
+//    @DisplayName("Should return voting session by ID")
+//    void getVotingResult_WithNoVotingSession_ShouldThrowException() {
+//        Pauta pauta = new Pauta();
+//        when(pautaQueryService.getPautaById(1L)).thenReturn(pauta);
+//        pauta.setVotingSession(null);
+//
+//        assertThrows(ResponseStatusException.class, () -> pautaManagementService.getVotingResult(1L));
+//
+//        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+//        assertEquals("Voting Session not found for the given Pauta ID1", exception.getReason());
+//        verify(pautaQueryService, times(1)).getPautaById(1L);
+//    }
 }

--- a/src/test/java/com/votacao/desafio/service/VoteServiceTest.java
+++ b/src/test/java/com/votacao/desafio/service/VoteServiceTest.java
@@ -1,0 +1,159 @@
+package com.votacao.desafio.service;
+
+import com.votacao.desafio.dto.VoteRequest;
+import com.votacao.desafio.dto.VotingResultResponse;
+import com.votacao.desafio.entity.Associate;
+import com.votacao.desafio.entity.Pauta;
+import com.votacao.desafio.entity.Vote;
+import com.votacao.desafio.entity.VotingSession;
+import com.votacao.desafio.repository.VoteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class VoteServiceTest {
+
+    @Mock
+    private PautaQueryService pautaService;
+
+    @Mock
+    private VotingSessionService votingSessionService;
+
+    @Mock
+    private AssociateService associateService;
+
+    @Mock
+    private VoteRepository voteRepository;
+
+    @Mock
+    private CpfValidationService cpfValidationService;
+
+    @InjectMocks
+    private VoteService voteService;
+
+    private Pauta pauta;
+    private VotingSession votingSession;
+    private Associate associate;
+    private VoteRequest voteRequest;
+    private String cpf;
+
+    @BeforeEach
+    void setUp() {
+        pauta = new Pauta();
+        pauta.setId(1L);
+        cpf = "06734690008";
+
+        votingSession = new VotingSession();
+        votingSession.setId(1L);
+        votingSession.setPauta(pauta);
+        votingSession.setVotingSessionStartedAt(LocalDateTime.now().minusMinutes(5));
+        votingSession.setVotingSessionEndedAt(LocalDateTime.now().plusMinutes(10));
+        votingSession.setVotes(new ArrayList<>());
+
+        pauta.setVotingSession(votingSession);
+
+        associate = new Associate();
+        associate.setId(1L);
+
+        voteRequest = new VoteRequest();
+        voteRequest.setCpf(cpf);
+        voteRequest.setVote(Vote.VoteOption.NO);
+    }
+
+    @Test
+    @DisplayName("Should register vote successfully")
+    void registerVote_WithValidData_ShouldRegisterVote() {
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+        when(votingSessionService.findById(1L)).thenReturn(votingSession);
+        when(cpfValidationService.validateCpf(cpf)).thenReturn(CpfValidationService.StatusVotacao.ABLE_TO_VOTE);
+        when(associateService.getAssociateByCpf(cpf)).thenReturn(associate);
+        when(voteRepository.save(any(Vote.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        VotingResultResponse result = voteService.registerVote(1L, voteRequest);
+
+        assertNotNull(result);
+        verify(voteRepository, times(1)).save(any(Vote.class));
+        verify(votingSessionService, times(1)).saveVotingSession(any(VotingSession.class));
+    }
+
+    @Test
+    @DisplayName("Should throw exception when Pauta has no voting session opened")
+    void registerVote_WhenPautaHasNoVotingSession_ShouldThrowException() {
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+        pauta.setVotingSession(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                voteService.registerVote(1L, voteRequest)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("Pauta with ID 1 does not have an voting session opened", exception.getReason());
+    }
+
+    @Test
+    @DisplayName("Should throw exception when CPF is invalid")
+    void registerVote_WithInvalidCpf_ShouldThrowException() {
+        pauta.setVotingSession(votingSession);
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+        when(votingSessionService.findById(1L)).thenReturn(votingSession);
+        when(cpfValidationService.validateCpf(cpf)).thenReturn(CpfValidationService.StatusVotacao.UNABLE_TO_VOTE);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                voteService.registerVote(1L, voteRequest)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("Invalid CPF " + cpf, exception.getReason());
+    }
+
+    @Test
+    @DisplayName("Should throw exception when voting session was ended")
+    void registerVote_WhenVotingSessionIsClosed_ShouldThrowException() {
+        pauta.setVotingSession(votingSession);
+        votingSession.setVotingSessionEndedAt(LocalDateTime.now().minusMinutes(1));
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+        when(votingSessionService.findById(1L)).thenReturn(votingSession);
+        when(cpfValidationService.validateCpf(cpf)).thenReturn(CpfValidationService.StatusVotacao.ABLE_TO_VOTE);
+        when(associateService.getAssociateByCpf(cpf)).thenReturn(associate);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                voteService.registerVote(1L, voteRequest)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("Voting session is closed", exception.getReason());
+    }
+
+    @Test
+    @DisplayName("Should throw exception when associate already voted")
+    void registerVote_WhenAssociateAlreadyVoted_ShouldThrowException() {
+        pauta.setVotingSession(votingSession);
+        votingSession.setVotes(Collections.singletonList(Vote.builder().associate(associate).build()));
+        when(pautaService.getPautaById(1L)).thenReturn(pauta);
+        when(votingSessionService.findById(1L)).thenReturn(votingSession);
+        when(cpfValidationService.validateCpf(cpf)).thenReturn(CpfValidationService.StatusVotacao.ABLE_TO_VOTE);
+        when(associateService.getAssociateByCpf(cpf)).thenReturn(associate);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
+                voteService.registerVote(1L, voteRequest)
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        assertEquals("Associate already voted", exception.getReason());
+    }
+}

--- a/src/test/java/com/votacao/desafio/service/VotingSessionServiceTest.java
+++ b/src/test/java/com/votacao/desafio/service/VotingSessionServiceTest.java
@@ -7,9 +7,10 @@ import com.votacao.desafio.repository.VotingSessionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -21,6 +22,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class VotingSessionServiceTest {
 
     @Mock
@@ -36,8 +38,6 @@ class VotingSessionServiceTest {
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
-
         pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "votingSessionStartedAt"));
     }
 
@@ -146,23 +146,6 @@ class VotingSessionServiceTest {
         assertEquals(1, result.getTotalElements());
         verify(votingSessionRepository, times(1)).listAllVotingSessionsClosed(any(LocalDateTime.class), eq(pageable));
         verifyNoMoreInteractions(votingSessionRepository);
-    }
-
-    @Test
-    @DisplayName("Should return voting session by ID")
-    void getVotingResult_WithNoVotingSession_ShouldThrowException() {
-        Pauta pauta = new Pauta();
-        when(pautaService.getPautaById(1L)).thenReturn(pauta);
-        when(votingSessionRepository.findOpenVotingSessionByPautaId(1L)).thenReturn(Optional.empty());
-
-        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () ->
-                votingSessionService.getVotingResult(1L)
-        );
-
-        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
-        assertEquals("Voting Session not found for the given Pauta ID1", exception.getReason());
-        verify(pautaService, times(1)).getPautaById(1L);
-        verify(votingSessionRepository, times(1)).findOpenVotingSessionByPautaId(1L);
     }
 
     @Test


### PR DESCRIPTION
Introduced unit tests for `VoteService` to validate vote registration scenarios, including successful cases and edge cases like invalid CPF and closed sessions. Refactored voting result calculations and retrieval to improve clarity and ensure they are handled by `PautaManagementService`. Simplified logic in DTOs and removed redundant calculation fields.